### PR TITLE
[feature] Reduce resources `requests.cpu`

### DIFF
--- a/roles/businesscard-openshift/tasks/app.yml
+++ b/roles/businesscard-openshift/tasks/app.yml
@@ -133,7 +133,7 @@
                   - containerPort: 8080
                 resources:
                   requests:
-                    cpu: "500m"
+                    cpu: "100m"
                     memory: "1Gi"
                 envFrom:
                   - configMapRef:


### PR DESCRIPTION
Since OpenShift licenses are based on CPU usage, we need to set appropriate values. 
These values are based on the metrics from the last two weeks.